### PR TITLE
Create post operation to create a new cv

### DIFF
--- a/src/main/java/com/oramirez/atowencv/controller/CVcontroller.java
+++ b/src/main/java/com/oramirez/atowencv/controller/CVcontroller.java
@@ -1,18 +1,16 @@
 package com.oramirez.atowencv.controller;
 
 import com.oramirez.atowencv.model.cv.CVmodel;
+import com.oramirez.atowencv.model.response.PostResponse;
 import com.oramirez.atowencv.service.CVservice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping(value = "/at-owen-cv/")
+@RequestMapping(value = "/at-owen-cv")
 public class CVcontroller {
 
     @Autowired
@@ -22,5 +20,11 @@ public class CVcontroller {
     @ResponseStatus(HttpStatus.OK)
     public List<CVmodel> getAllCVs() {
         return cVservice.getAllCVs();
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(value = "/cv", consumes = "application/json", produces = "application/json")
+    public PostResponse createNewCV(@RequestBody CVmodel request) {
+        return cVservice.createNewCV(request);
     }
 }

--- a/src/main/java/com/oramirez/atowencv/controller/IndexController.java
+++ b/src/main/java/com/oramirez/atowencv/controller/IndexController.java
@@ -1,0 +1,17 @@
+package com.oramirez.atowencv.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/")
+public class IndexController {
+
+    @GetMapping
+    public String indexController() {
+        return "<h1 style=\"margin-top: 3.125rem; font-family: arial; text-align: center;\">Welcome to Owen's cv API. " +
+                "Go to <a href=#>/at-owen-cv</a> to start</h1>";
+    }
+
+}

--- a/src/main/java/com/oramirez/atowencv/service/CVservice.java
+++ b/src/main/java/com/oramirez/atowencv/service/CVservice.java
@@ -1,9 +1,11 @@
 package com.oramirez.atowencv.service;
 
 import com.oramirez.atowencv.model.cv.CVmodel;
+import com.oramirez.atowencv.model.response.PostResponse;
 
 import java.util.List;
 
 public interface CVservice {
     List<CVmodel> getAllCVs();
+    PostResponse createNewCV(CVmodel request);
 }

--- a/src/main/java/com/oramirez/atowencv/service/implementation/CVserviceImplementation.java
+++ b/src/main/java/com/oramirez/atowencv/service/implementation/CVserviceImplementation.java
@@ -1,6 +1,7 @@
 package com.oramirez.atowencv.service.implementation;
 
 import com.oramirez.atowencv.model.cv.CVmodel;
+import com.oramirez.atowencv.model.response.PostResponse;
 import com.oramirez.atowencv.repository.CVrepository;
 import com.oramirez.atowencv.service.CVservice;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,5 +20,13 @@ public class CVserviceImplementation implements CVservice {
         List<CVmodel> userCVs = cVrepository.findAll();
 
         return userCVs;
+    }
+
+    @Override
+    public PostResponse createNewCV(CVmodel request) {
+        System.out.println("The request -> " + request);
+        CVmodel saveNewCV = cVrepository.save(request);
+        System.out.println("Saved = " + saveNewCV);
+        return new PostResponse(saveNewCV.getId());
     }
 }


### PR DESCRIPTION
# Main feature

In the path `/at-owen-cv/cv` we are going to receive all the request from the POST operation to create a new cv with these fields
- User's personal information (name, email, phone, etc.)
- User's skills
- User's languages
- User's work experience
- User's education
- User's social media
- User's challenges

## Secondary feature

Every time when we are in the root path `/`, now we are going to watch a welcome message instead of the default message that spring boot added

![imagen](https://user-images.githubusercontent.com/78741607/119025238-8d676400-b969-11eb-9ed0-9aaf70ce0ab8.png)
