### PR TITLE
Rename api endpoints

### DIFF
--- a/src/main/java/com/oramirez/atowencv/controller/CVcontroller.java
+++ b/src/main/java/com/oramirez/atowencv/controller/CVcontroller.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping(value = "/at-owen-cv")
+@RequestMapping(value = "/at-owen-cv/cvs")
 public class CVcontroller {
 
     @Autowired
@@ -29,7 +29,7 @@ public class CVcontroller {
     }
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping(value = "/cv", consumes = "application/json", produces = "application/json")
+    @PostMapping(consumes = "application/json", produces = "application/json")
     public PostResponse createNewCV(@RequestBody CVmodel request) {
         return cVservice.createNewCV(request);
     }

--- a/src/main/java/com/oramirez/atowencv/service/implementation/CVserviceImplementation.java
+++ b/src/main/java/com/oramirez/atowencv/service/implementation/CVserviceImplementation.java
@@ -41,9 +41,7 @@ public class CVserviceImplementation implements CVservice {
 
     @Override
     public PostResponse createNewCV(CVmodel request) {
-        System.out.println("The request -> " + request);
         CVmodel saveNewCV = cVrepository.save(request);
-        System.out.println("Saved = " + saveNewCV);
         return new PostResponse(saveNewCV.getId());
     }
 


### PR DESCRIPTION
Follow best practices in REST API development, the endpoints were renamed.

There is a problem in front end site, it is caused because it wants to access an endpoint that did not exist, so that is why the rename of the endpoints is require 